### PR TITLE
Updated README, Fixed test paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ with other users.
 
    to install dependencies
 
-3. Run
+3. Create a `.env` file that sets up a `PORT` variable to `5000`.
+
+```bash
+echo "PORT=5000" > .env
+```
+
+4. Run
 
    ```bash
    npm run dev
@@ -29,7 +35,7 @@ with other users.
 
    to start the live server
 
-4. Now visit `http://localhost:5000` to view the website
+5. Now visit `http://localhost:5000` to view the website
 
 ## Day 1
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "db:reset": "sqlite3 db/db.sqlite < db/migrations/1-reset.sql",
     "db:seed": "sqlite3 db/db.sqlite < db/migrations/2-seed.sql",
     "dev": "nodemon server/run.js",
-    "test": "mocha",
+    "test": "mocha ./test/exercises/",
     "test:d1e1": "mocha ./test/exercises/d1e1.test.js",
     "test:d1e2": "mocha ./test/exercises/d1e2.test.js",
     "test:d1e3": "mocha ./test/exercises/d1e3.test.js",

--- a/test/exercises/d1e1.test.js
+++ b/test/exercises/d1e1.test.js
@@ -1,15 +1,15 @@
 // test/d1e1.test.js
-import { strict as assert } from 'assert'
-import request from 'supertest'
-import app from '../exercises/d1e1.js'
+import { strict as assert } from "assert";
+import request from "supertest";
+import app from "../../exercises/d1e1.js";
 
-describe('GET /success.jpg', function () {
-  it('should return 200 OK and the image', async function () {
+describe("GET /success.jpg", function () {
+  it("should return 200 OK and the image", async function () {
     const response = await request(app)
-      .get('/success.jpg')
-      .expect('Content-Type', /image\/jpeg/)
-      .expect(200)
+      .get("/success.jpg")
+      .expect("Content-Type", /image\/jpeg/)
+      .expect(200);
 
-    assert.ok(response.body.length > 0, 'Image should not be empty')
-  })
-})
+    assert.ok(response.body.length > 0, "Image should not be empty");
+  });
+});

--- a/test/exercises/d1e2.test.js
+++ b/test/exercises/d1e2.test.js
@@ -1,22 +1,22 @@
 // test/d1e2.test.js
-import { strict as assert } from 'assert'
-import request from 'supertest'
-import * as cheerio from 'cheerio'
-import app from '../exercises/d1e2.js'
+import { strict as assert } from "assert";
+import request from "supertest";
+import * as cheerio from "cheerio";
+import app from "../../exercises/d1e2.js";
 
-describe('GET /d1e2', function () {
-  it('should render the view with the message', async function () {
+describe("GET /d1e2", function () {
+  it("should render the view with the message", async function () {
     const response = await request(app)
-      .get('/d1e2')
-      .expect('Content-Type', /html/)
-      .expect(200)
+      .get("/d1e2")
+      .expect("Content-Type", /html/)
+      .expect(200);
 
-    const $ = cheerio.load(response.text)
-    const h1Text = $('h1').text().trim()
+    const $ = cheerio.load(response.text);
+    const h1Text = $("h1").text().trim();
 
     assert.ok(
-      h1Text.includes('Hello from d1e2!'),
-      'h1 should contain the message'
-    )
-  })
-})
+      h1Text.includes("Hello from d1e2!"),
+      "h1 should contain the message"
+    );
+  });
+});

--- a/test/exercises/d1e3.test.js
+++ b/test/exercises/d1e3.test.js
@@ -1,33 +1,33 @@
-import { strict as assert } from 'assert'
-import request from 'supertest'
-import * as cheerio from 'cheerio'
-import app from '../exercises/d1e3.js'
+import { strict as assert } from "assert";
+import request from "supertest";
+import * as cheerio from "cheerio";
+import app from "../../exercises/d1e3.js";
 
-describe('GET /d1e3', function () {
-  it('should render the view with the shopping list', async function () {
+describe("GET /d1e3", function () {
+  it("should render the view with the shopping list", async function () {
     const response = await request(app)
-      .get('/d1e3')
-      .expect('Content-Type', /html/)
-      .expect(200)
+      .get("/d1e3")
+      .expect("Content-Type", /html/)
+      .expect(200);
 
-    const $ = cheerio.load(response.text)
-    const items = $('ul li')
+    const $ = cheerio.load(response.text);
+    const items = $("ul li")
       .map((_, el) => $(el).text().trim())
-      .get()
+      .get();
 
     const expectedItems = [
-      'Eggs',
-      'Flour',
-      'Sugar',
-      'Lifesize cutout of Christian Bale as Batman',
-      'Milk',
-      'Bread'
-    ]
+      "Eggs",
+      "Flour",
+      "Sugar",
+      "Lifesize cutout of Christian Bale as Batman",
+      "Milk",
+      "Bread",
+    ];
 
     assert.deepStrictEqual(
       items,
       expectedItems,
-      'The shopping list should match the expected items'
-    )
-  })
-})
+      "The shopping list should match the expected items"
+    );
+  });
+});

--- a/test/exercises/d2e1.test.js
+++ b/test/exercises/d2e1.test.js
@@ -1,23 +1,23 @@
 // test/d2e1.test.js
-import { strict as assert } from 'assert'
-import request from 'supertest'
-import * as cheerio from 'cheerio'
-import app from '../exercises/d2e1.js'
+import { strict as assert } from "assert";
+import request from "supertest";
+import * as cheerio from "cheerio";
+import app from "../../exercises/d2e1.js";
 
-describe('GET /d2e1', function () {
-  it('should render the view with the marketing partial content', async function () {
+describe("GET /d2e1", function () {
+  it("should render the view with the marketing partial content", async function () {
     const response = await request(app)
-      .get('/d2e1')
-      .expect('Content-Type', /html/)
-      .expect(200)
+      .get("/d2e1")
+      .expect("Content-Type", /html/)
+      .expect(200);
 
-    const $ = cheerio.load(response.text)
-    const marketingText = $('marquee').text()
+    const $ = cheerio.load(response.text);
+    const marketingText = $("marquee").text();
 
     assert.strictEqual(
       marketingText,
-      'We have been trying to contact you about your car insurance!',
-      'The marketing section should contain the expected text'
-    )
-  })
-})
+      "We have been trying to contact you about your car insurance!",
+      "The marketing section should contain the expected text"
+    );
+  });
+});

--- a/test/exercises/d2e2.test.js
+++ b/test/exercises/d2e2.test.js
@@ -1,39 +1,39 @@
-import { strict as assert } from 'assert'
-import request from 'supertest'
-import * as cheerio from 'cheerio'
-import app from '../exercises/d2e2.js'
+import { strict as assert } from "assert";
+import request from "supertest";
+import * as cheerio from "cheerio";
+import app from "../../exercises/d2e2.js";
 
-describe('GET /d2e1', function () {
-  it('should render the view with the image', async function () {
+describe("GET /d2e1", function () {
+  it("should render the view with the image", async function () {
     const response = await request(app)
-      .get('/d2e2')
-      .expect('Content-Type', /html/)
-      .expect(200)
+      .get("/d2e2")
+      .expect("Content-Type", /html/)
+      .expect(200);
 
-    const $ = cheerio.load(response.text)
-    const img = $('img')
-    const src = img.attr('src')
+    const $ = cheerio.load(response.text);
+    const img = $("img");
+    const src = img.attr("src");
 
     const imgResponse = await request(app)
       .get(src)
-      .expect('Content-Type', /image\/jpeg/)
-      .expect(200)
+      .expect("Content-Type", /image\/jpeg/)
+      .expect(200);
 
-    assert.strictEqual(src, '/success.jpg', 'Image src should be /success.jpg')
-    assert(imgResponse.body.length > 0, 'Image should not be empty')
-  })
+    assert.strictEqual(src, "/success.jpg", "Image src should be /success.jpg");
+    assert(imgResponse.body.length > 0, "Image should not be empty");
+  });
 
-  it('image should have correct alt text', async function () {
-    const response = await request(app).get('/d2e2')
+  it("image should have correct alt text", async function () {
+    const response = await request(app).get("/d2e2");
 
-    const $ = cheerio.load(response.text)
-    const img = $('img')
-    const alt = img.attr('alt').trim().toLocaleLowerCase()
+    const $ = cheerio.load(response.text);
+    const img = $("img");
+    const alt = img.attr("alt").trim().toLocaleLowerCase();
 
     assert.strictEqual(
       alt,
-      'success kid',
+      "success kid",
       'Image alt text should be "Success Kid"'
-    )
-  })
-})
+    );
+  });
+});

--- a/test/exercises/d2e3.test.js
+++ b/test/exercises/d2e3.test.js
@@ -1,42 +1,42 @@
-import { strict as assert } from 'assert'
-import request from 'supertest'
-import * as cheerio from 'cheerio'
-import app from '../exercises/d2e3.js'
+import { strict as assert } from "assert";
+import request from "supertest";
+import * as cheerio from "cheerio";
+import app from "../../exercises/d2e3.js";
 
-describe('GET /d2e3', function () {
-  it('should render the form', async function () {
+describe("GET /d2e3", function () {
+  it("should render the form", async function () {
     const response = await request(app)
-      .get('/d2e3')
-      .expect('Content-Type', /html/)
-      .expect(200)
+      .get("/d2e3")
+      .expect("Content-Type", /html/)
+      .expect(200);
 
-    const $ = cheerio.load(response.text)
-    const form = $('form')
-    assert(form.length, 'Form should be present')
+    const $ = cheerio.load(response.text);
+    const form = $("form");
+    assert(form.length, "Form should be present");
     assert.strictEqual(
-      form.attr('action'),
-      '/submit',
-      'Form action should be /submit'
-    )
+      form.attr("action"),
+      "/submit",
+      "Form action should be /submit"
+    );
     assert.strictEqual(
-      form.attr('method'),
-      'post',
-      'Form method should be post'
-    )
-  })
-})
+      form.attr("method"),
+      "post",
+      "Form method should be post"
+    );
+  });
+});
 
-describe('POST /submit', function () {
-  it('should receive form data', async function () {
+describe("POST /submit", function () {
+  it("should receive form data", async function () {
     const response = await request(app)
-      .post('/submit')
-      .type('form')
-      .send({ name: 'John Doe', email: 'john@example.com' })
-      .expect(200)
+      .post("/submit")
+      .type("form")
+      .send({ name: "John Doe", email: "john@example.com" })
+      .expect(200);
 
     assert(
-      response.text.includes('Received: John Doe, john@example.com'),
-      'Response should contain the submitted data'
-    )
-  })
-})
+      response.text.includes("Received: John Doe, john@example.com"),
+      "Response should contain the submitted data"
+    );
+  });
+});


### PR DESCRIPTION
Hey,

I have added an extra step to include adding a `.env` file with the port value to the README.

The paths were broken in the tests, and the learners got module not found errors when running tests, so I have fixed those as well.

I have looked at my changes and my auto formatter has changed ' to ". 

I don't think it should matter, but let me know if you want me to remove that?
